### PR TITLE
fix: minor typo in help string for process_threads

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,7 +193,7 @@ impl Collector {
         describe_gauge!(
             format!("{}process_threads", prefix),
             Unit::Count,
-            "Numberof OS threads in the process."
+            "Number of OS threads in the process."
         );
     }
 


### PR DESCRIPTION
Fix typo: `Numberof` => `Number of`