### PR TITLE
Update `metrics` dependency from 0.21.0 to 0.22.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,10 +27,7 @@ jobs:
           cargo fmt --version
       - name: Format
         run: |
-          cargo fmt
-      - name: Diff check
-        run: |
-          test -z "$(git status -s)"
+          cargo fmt --check
 
   check:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ description = "Cross-platform Prometheus style process metrics collector of metr
 repository = "https://github.com/lambdalisue/rs-metrics-process"
 license = "MIT"
 readme = "README.md"
-keywords = ["cross-platform", "metrics", "prometheus", "open-metrics", "process"]
+keywords = [ "cross-platform", "metrics", "prometheus", "open-metrics", "process", ]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ all-features = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-metrics = "0.21.0"
+metrics = "0.22.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 libproc = "0.14.2"
@@ -39,5 +39,5 @@ features = [
 [dev-dependencies]
 assert_matches = "1.5.0"
 axum = "0.7.2"
-metrics-exporter-prometheus = "0.12.0"
+metrics-exporter-prometheus = "0.13.0"
 tokio = { version = "1.20.1", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 
 # ⏱ metrics-process
 
-This crate provides [Prometheus][] style [process metrics][] collector of [metrics][] crate for Linux, macOS, and Windows.
-Collector code is manually re-written to Rust from an official prometheus client of go ([client_golang][])
+This crate provides [Prometheus] style [process metrics] collector of [metrics] crate for Linux, macOS, and Windows.
+Collector code is manually re-written to Rust from an official prometheus client of go ([client_golang])
 
 [prometheus]: https://prometheus.io/
 [process metrics]: https://prometheus.io/docs/instrumenting/writing_clientlibs/#process-metrics
@@ -17,7 +17,7 @@ Collector code is manually re-written to Rust from an official prometheus client
 
 ## Supported metrics
 
-This crate supports the following metrics, equal to what official prometheus client of go ([client_golang][]) provides.
+This crate supports the following metrics, equal to what official prometheus client of go ([client_golang]) provides.
 
 | Metric name                        | Help string                                            | Linux | macOS | Windows |
 | ---------------------------------- | ------------------------------------------------------ | ----- | ----- | ------- |
@@ -35,11 +35,11 @@ This crate supports the following metrics, equal to what official prometheus cli
 
 ## Usage
 
-Use this crate with [metrics-exporter-prometheus][] as an exporter like:
+Use this crate with [metrics-exporter-prometheus] as an exporter like:
 
 [metrics-exporter-prometheus]: https://crates.io/crates/metrics-exporter-prometheus
 
-```rust
+```rust,no_run
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -63,12 +63,12 @@ loop {
 }
 ```
 
-Or with [axum][] (or any web application framework you like) to collect metrics whenever
+Or with [axum] (or any web application framework you like) to collect metrics whenever
 the `/metrics` endpoint is invoked like:
 
 [axum]: https://crates.io/crates/axum
 
-```rust
+```rust,no_run
 use axum::{routing::get, Router, Server};
 use metrics_exporter_prometheus::PrometheusBuilder;
 use metrics_process::Collector;
@@ -100,9 +100,9 @@ async fn main() {
 }
 ```
 
-## Difference from [metrics-process-promstyle][]
+## Difference from [metrics-process-promstyle]
 
-It seems [metrics-process-promstyle][] only support Linux but this crate (metrics-process) supports Linux, macOS, and Windows.
+It seems [metrics-process-promstyle] only support Linux but this crate (metrics-process) supports Linux, macOS, and Windows.
 Additionally, this crate supports `process_open_fds` and `process_max_fds` addition to what metrics-process-promstyle supports.
 
 [metrics-process-promstyle]: https://crates.io/crates/metrics-process-promstyle

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Use this crate with [metrics-exporter-prometheus] as an exporter like:
 
 [metrics-exporter-prometheus]: https://crates.io/crates/metrics-exporter-prometheus
 
-```rust,no_run
+```rust
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -68,10 +68,11 @@ the `/metrics` endpoint is invoked like:
 
 [axum]: https://crates.io/crates/axum
 
-```rust,no_run
-use axum::{routing::get, Router, Server};
+```rust
+use axum::{routing::get, Router};
 use metrics_exporter_prometheus::PrometheusBuilder;
 use metrics_process::Collector;
+use tokio::net::TcpListener;
 
 #[tokio::main]
 async fn main() {
@@ -93,10 +94,8 @@ async fn main() {
             std::future::ready(handle.render())
         }),
     );
-    Server::bind(&addr)
-        .serve(app.into_make_service())
-        .await
-        .unwrap();
+    let listener = TcpListener::bind("127.0.0.1:9000").await.unwrap();
+    axum::serve(listener, app).await.unwrap();
 }
 ```
 

--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-metrics = "0.20.1"
-metrics-exporter-prometheus = "0.11.0"
+metrics = "0.22.0"
+metrics-exporter-prometheus = "0.13.0"
 metrics-process = { path = "../../"}
 rand = "0.8.5"

--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2021"
 [dependencies]
 metrics = "0.22.0"
 metrics-exporter-prometheus = "0.13.0"
-metrics-process = { path = "../../"}
+metrics-process = { path = "../../" }
 rand = "0.8.5"

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -1,6 +1,6 @@
 # basic
 
-An example code of `metrics-process` with [metrics-exporter-prometheus][].
+An example code of `metrics-process` with [metrics-exporter-prometheus].
 
 [metrics-exporter-prometheus]: https://crates.io/crates/metrics-exporter-prometheus
 

--- a/examples/with_axum/Cargo.toml
+++ b/examples/with_axum/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-axum = "0.5.15"
+axum = "0.7.2"
 metrics = "0.22.0"
 metrics-exporter-prometheus = { version = "0.13.0", default-features = false }
-metrics-process = { path = "../../"}
+metrics-process = { path = "../../" }
 tokio = { version = "1.20.1", features = ["full"] }

--- a/examples/with_axum/Cargo.toml
+++ b/examples/with_axum/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 axum = "0.5.15"
-metrics = "0.20.1"
-metrics-exporter-prometheus = { version = "0.11.0", default-features = false }
+metrics = "0.22.0"
+metrics-exporter-prometheus = { version = "0.13.0", default-features = false }
 metrics-process = { path = "../../"}
 tokio = { version = "1.20.1", features = ["full"] }

--- a/examples/with_axum/README.md
+++ b/examples/with_axum/README.md
@@ -1,6 +1,6 @@
 # with_axum
 
-An example of `metrics-process` crate with [axum][] and [metrics-exporter-prometheus][].
+An example of `metrics-process` crate with [axum] and [metrics-exporter-prometheus].
 
 [axum]: https://crates.io/crates/axum
 [metrics-exporter-prometheus]: https://crates.io/crates/metrics-exporter-prometheus

--- a/examples/with_axum/src/main.rs
+++ b/examples/with_axum/src/main.rs
@@ -1,6 +1,7 @@
-use axum::{routing::get, Router, Server};
+use axum::{routing::get, Router};
 use metrics_exporter_prometheus::PrometheusBuilder;
 use metrics_process::Collector;
+use tokio::net::TcpListener;
 
 #[tokio::main]
 async fn main() {
@@ -13,7 +14,6 @@ async fn main() {
     // Call `describe()` method to register help string.
     collector.describe();
 
-    let addr = "127.0.0.1:9000".parse().unwrap();
     let app = Router::new().route(
         "/metrics",
         get(move || {
@@ -22,8 +22,6 @@ async fn main() {
             std::future::ready(handle.render())
         }),
     );
-    Server::bind(&addr)
-        .serve(app.into_make_service())
-        .await
-        .unwrap();
+    let listener = TcpListener::bind("127.0.0.1:9000").await.unwrap();
+    axum::serve(listener, app).await.unwrap();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,99 @@
-#![doc = include_str!("../README.md")]
+//! This crate provides [Prometheus] style [process metrics] collector of [metrics] crate for Linux, macOS, and Windows.
+//! Collector code is manually re-written to Rust from an official prometheus client of go ([client_golang])
+//!
+//! [Prometheus]: https://prometheus.io/
+//! [process metrics]: https://prometheus.io/docs/instrumenting/writing_clientlibs/#process-metrics
+//! [metrics]: https://crates.io/crates/metrics
+//!
+//! # Supported metrics
+//!
+//! This crate supports the following metrics, equal to what official prometheus client of go ([client_golang]) provides.
+//!
+//! | Metric name                        | Help string                                            | Linux | macOS | Windows |
+//! | ---------------------------------- | ------------------------------------------------------ | ----- | ----- | ------- |
+//! | `process_cpu_seconds_total`        | Total user and system CPU time spent in seconds.       | x     | x     | x       |
+//! | `process_open_fds`                 | Number of open file descriptors.                       | x     | x     | x       |
+//! | `process_max_fds`                  | Maximum number of open file descriptors.               | x     | x     | x       |
+//! | `process_virtual_memory_bytes`     | Virtual memory size in bytes.                          | x     | x     | x       |
+//! | `process_virtual_memory_max_bytes` | Maximum amount of virtual memory available in bytes.   | x     | x     |         |
+//! | `process_resident_memory_bytes`    | Resident memory size in bytes.                         | x     | x     | x       |
+//! | `process_heap_bytes`               | Process heap size in bytes.                            |       |       |         |
+//! | `process_start_time_seconds`       | Start time of the process since unix epoch in seconds. | x     | x     | x       |
+//! | `process_threads`                  | Number of OS threads in the process.                   | x     | x     |         |
+//!
+//! [client_golang]: https://github.com/prometheus/client_golang
+//!
+//! # Usage
+//!
+//! Use this crate with [metrics-exporter-prometheus] as an exporter like:
+//!
+//! [metrics-exporter-prometheus]: https://crates.io/crates/metrics-exporter-prometheus
+//!
+//! ```no_run
+//! use std::thread;
+//! use std::time::{Duration, Instant};
+//!
+//! use metrics_exporter_prometheus::PrometheusBuilder;
+//! use metrics_process::Collector;
+//!
+//! let builder = PrometheusBuilder::new();
+//! builder
+//!     .install()
+//!     .expect("failed to install Prometheus recorder");
+//!
+//! let collector = Collector::default();
+//! // Call `describe()` method to register help string.
+//! collector.describe();
+//!
+//! loop {
+//!     let s = Instant::now();
+//!     // Periodically call `collect()` method to update information.
+//!     collector.collect();
+//!     thread::sleep(Duration::from_millis(750));
+//! }
+//! ```
+//!
+//! Or with [axum] (or any web application framework you like) to collect metrics whenever
+//! the `/metrics` endpoint is invoked like:
+//!
+//! [axum]: https://crates.io/crates/axum
+//!
+//! ```no_run
+//! use axum::{routing::get, Router};
+//! use metrics_exporter_prometheus::PrometheusBuilder;
+//! use metrics_process::Collector;
+//! use tokio::net::TcpListener;
+//!
+//! #[tokio::main]
+//! async fn main() {
+//!     let builder = PrometheusBuilder::new();
+//!     let handle = builder
+//!         .install_recorder()
+//!         .expect("failed to install Prometheus recorder");
+//!
+//!     let collector = Collector::default();
+//!     // Call `describe()` method to register help string.
+//!     collector.describe();
+//!
+//!     let app = Router::new().route(
+//!         "/metrics",
+//!         get(move || {
+//!             // Collect information just before handle '/metrics'
+//!             collector.collect();
+//!             std::future::ready(handle.render())
+//!         }),
+//!     );
+//!     let listener = TcpListener::bind("127.0.0.1:3000").await.unwrap();
+//!     axum::serve(listener, app).await.unwrap();
+//! }
+//! ```
+//!
+//! # Difference from [metrics-process-promstyle]
+//!
+//! It seems [metrics-process-promstyle] only support Linux but this crate (metrics-process) supports Linux, macOS, and Windows.
+//! Additionally, this crate supports `process_open_fds` and `process_max_fds` addition to what metrics-process-promstyle supports.
+//!
+//! [metrics-process-promstyle]: https://crates.io/crates/metrics-process-promstyle
 
 mod collector;
 
@@ -7,18 +102,11 @@ use metrics::{describe_gauge, gauge, Unit};
 /// Prometheus style process metrics collector
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Collector {
-    cpu_seconds_total: &'static str,
-    open_fds: &'static str,
-    max_fds: &'static str,
-    virtual_memory_bytes: &'static str,
-    virtual_memory_max_bytes: &'static str,
-    resident_memory_bytes: &'static str,
-    start_time_seconds: &'static str,
-    threads: &'static str,
+    prefix: String,
 }
 
 impl Default for Collector {
-    /// Create a new Collector instance without prefix.
+    /// Create a new Collector instance
     ///
     /// # Examples
     ///
@@ -27,16 +115,7 @@ impl Default for Collector {
     /// let collector = Collector::default();
     /// ```
     fn default() -> Self {
-        Self {
-            cpu_seconds_total: "process_cpu_seconds_total",
-            open_fds: "process_open_fds",
-            max_fds: "process_max_fds",
-            virtual_memory_bytes: "process_virtual_memory_bytes",
-            virtual_memory_max_bytes: "process_virtual_memory_max_bytes",
-            resident_memory_bytes: "process_resident_memory_bytes",
-            start_time_seconds: "process_start_time_seconds",
-            threads: "process_threads",
-        }
+        Self { prefix: "".into() }
     }
 }
 
@@ -46,20 +125,11 @@ impl Collector {
     ///
     /// ```
     /// # use metrics_process::Collector;
-    /// let collector = Collector::new("my_prefix_");
+    /// let collector = Collector::default().prefix("my_prefix_");
     /// ```
-    pub fn new(prefix: impl AsRef<str>) -> Self {
-        let prefix = prefix.as_ref();
-        Self {
-            cpu_seconds_total: format!("{prefix}process_cpu_seconds_total").leak(),
-            open_fds: format!("{prefix}process_open_fds").leak(),
-            max_fds: format!("{prefix}process_max_fds").leak(),
-            virtual_memory_bytes: format!("{prefix}process_virtual_memory_bytes").leak(),
-            virtual_memory_max_bytes: format!("{prefix}process_virtual_memory_max_bytes").leak(),
-            resident_memory_bytes: format!("{prefix}process_resident_memory_bytes").leak(),
-            start_time_seconds: format!("{prefix}process_start_time_seconds").leak(),
-            threads: format!("{prefix}process_threads").leak(),
-        }
+    pub fn prefix(mut self, prefix: impl Into<String>) -> Self {
+        self.prefix = prefix.into();
+        self
     }
 
     /// Describe available metrics through `describe_gauge!` macro of `metrics` crate.
@@ -81,45 +151,46 @@ impl Collector {
     /// # }
     /// ```
     pub fn describe(&self) {
+        let prefix = &self.prefix;
         describe_gauge!(
-            self.cpu_seconds_total,
+            format!("{}process_cpu_seconds_total", prefix),
             Unit::Seconds,
             "Total user and system CPU time spent in seconds."
         );
         describe_gauge!(
-            self.open_fds,
+            format!("{}process_open_fds", prefix),
             Unit::Count,
             "Number of open file descriptors."
         );
         describe_gauge!(
-            self.max_fds,
+            format!("{}process_max_fds", prefix),
             Unit::Count,
             "Maximum number of open file descriptors."
         );
         describe_gauge!(
-            self.virtual_memory_bytes,
+            format!("{}process_virtual_memory_bytes", prefix),
             Unit::Bytes,
             "Virtual memory size in bytes."
         );
         #[cfg(not(target_os = "windows"))]
         describe_gauge!(
-            self.virtual_memory_max_bytes,
+            format!("{}process_virtual_memory_max_bytes", prefix),
             Unit::Bytes,
             "Maximum amount of virtual memory available in bytes."
         );
         describe_gauge!(
-            self.resident_memory_bytes,
+            format!("{}process_resident_memory_bytes", prefix),
             Unit::Bytes,
             "Resident memory size in bytes."
         );
         describe_gauge!(
-            self.start_time_seconds,
+            format!("{}process_start_time_seconds", prefix),
             Unit::Seconds,
             "Start time of the process since unix epoch in seconds."
         );
         #[cfg(not(target_os = "windows"))]
         describe_gauge!(
-            self.threads,
+            format!("{}process_threads", prefix),
             Unit::Count,
             "Number of OS threads in the process."
         );
@@ -145,32 +216,33 @@ impl Collector {
     /// # }
     /// ```
     pub fn collect(&self) {
+        let prefix = &self.prefix;
         let mut m = collector::collect();
         if let Some(v) = m.cpu_seconds_total.take() {
-            gauge!(self.cpu_seconds_total).set(v as f64);
+            gauge!(format!("{}process_cpu_seconds_total", prefix)).set(v);
         }
         if let Some(v) = m.open_fds.take() {
-            gauge!(self.open_fds).set(v as f64);
+            gauge!(format!("{}process_open_fds", prefix)).set(v as f64);
         }
         if let Some(v) = m.max_fds.take() {
-            gauge!(self.max_fds).set(v as f64);
+            gauge!(format!("{}process_max_fds", prefix)).set(v as f64);
         }
         if let Some(v) = m.virtual_memory_bytes.take() {
-            gauge!(self.virtual_memory_bytes).set(v as f64);
+            gauge!(format!("{}process_virtual_memory_bytes", prefix)).set(v as f64);
         }
         #[cfg(not(target_os = "windows"))]
         if let Some(v) = m.virtual_memory_max_bytes.take() {
-            gauge!(self.virtual_memory_max_bytes).set(v as f64);
+            gauge!(format!("{}process_virtual_memory_max_bytes", prefix)).set(v as f64);
         }
         if let Some(v) = m.resident_memory_bytes.take() {
-            gauge!(self.resident_memory_bytes).set(v as f64);
+            gauge!(format!("{}process_resident_memory_bytes", prefix)).set(v as f64);
         }
         if let Some(v) = m.start_time_seconds.take() {
-            gauge!(self.start_time_seconds).set(v as f64);
+            gauge!(format!("{}process_start_time_seconds", prefix)).set(v as f64);
         }
         #[cfg(not(target_os = "windows"))]
         if let Some(v) = m.threads.take() {
-            gauge!(self.threads).set(v as f64);
+            gauge!(format!("{}process_threads", prefix)).set(v as f64);
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,101 +1,5 @@
-//! This crate provides [Prometheus][] style [process metrics][] collector of [metrics][] crate for Linux, macOS, and Windows.
-//! Collector code is manually re-written to Rust from an official prometheus client of go ([client_golang][])
-//!
-//! [Prometheus]: https://prometheus.io/
-//! [process metrics]: https://prometheus.io/docs/instrumenting/writing_clientlibs/#process-metrics
-//! [metrics]: https://crates.io/crates/metrics
-//!
-//! # Supported metrics
-//!
-//! This crate supports the following metrics, equal to what official prometheus client of go ([client_golang][]) provides.
-//!
-//! | Metric name                        | Help string                                            | Linux | macOS | Windows |
-//! | ---------------------------------- | ------------------------------------------------------ | ----- | ----- | ------- |
-//! | `process_cpu_seconds_total`        | Total user and system CPU time spent in seconds.       | x     | x     | x       |
-//! | `process_open_fds`                 | Number of open file descriptors.                       | x     | x     | x       |
-//! | `process_max_fds`                  | Maximum number of open file descriptors.               | x     | x     | x       |
-//! | `process_virtual_memory_bytes`     | Virtual memory size in bytes.                          | x     | x     | x       |
-//! | `process_virtual_memory_max_bytes` | Maximum amount of virtual memory available in bytes.   | x     | x     |         |
-//! | `process_resident_memory_bytes`    | Resident memory size in bytes.                         | x     | x     | x       |
-//! | `process_heap_bytes`               | Process heap size in bytes.                            |       |       |         |
-//! | `process_start_time_seconds`       | Start time of the process since unix epoch in seconds. | x     | x     | x       |
-//! | `process_threads`                  | Number of OS threads in the process.                   | x     | x     |         |
-//!
-//! [client_golang]: https://github.com/prometheus/client_golang
-//!
-//! # Usage
-//!
-//! Use this crate with [metrics-exporter-prometheus][] as an exporter like:
-//!
-//! [metrics-exporter-prometheus]: https://crates.io/crates/metrics-exporter-prometheus
-//!
-//! ```no_run
-//! use std::thread;
-//! use std::time::{Duration, Instant};
-//!
-//! use metrics_exporter_prometheus::PrometheusBuilder;
-//! use metrics_process::Collector;
-//!
-//! let builder = PrometheusBuilder::new();
-//! builder
-//!     .install()
-//!     .expect("failed to install Prometheus recorder");
-//!
-//! let collector = Collector::default();
-//! // Call `describe()` method to register help string.
-//! collector.describe();
-//!
-//! loop {
-//!     let s = Instant::now();
-//!     // Periodically call `collect()` method to update information.
-//!     collector.collect();
-//!     thread::sleep(Duration::from_millis(750));
-//! }
-//! ```
-//!
-//! Or with [axum][] (or any web application framework you like) to collect metrics whenever
-//! the `/metrics` endpoint is invoked like:
-//!
-//! [axum]: https://crates.io/crates/axum
-//!
-//! ```no_run
-//! use axum::{routing::get, Router, Server};
-//! use metrics_exporter_prometheus::PrometheusBuilder;
-//! use metrics_process::Collector;
-//!
-//! #[tokio::main]
-//! async fn main() {
-//!     let builder = PrometheusBuilder::new();
-//!     let handle = builder
-//!         .install_recorder()
-//!         .expect("failed to install Prometheus recorder");
-//!
-//!     let collector = Collector::default();
-//!     // Call `describe()` method to register help string.
-//!     collector.describe();
-//!
-//!     let addr = "127.0.0.1:9000".parse().unwrap();
-//!     let app = Router::new().route(
-//!         "/metrics",
-//!         get(move || {
-//!             // Collect information just before handle '/metrics'
-//!             collector.collect();
-//!             std::future::ready(handle.render())
-//!         }),
-//!     );
-//!     Server::bind(&addr)
-//!         .serve(app.into_make_service())
-//!         .await
-//!         .unwrap();
-//! }
-//! ```
-//!
-//! # Difference from [metrics-process-promstyle][]
-//!
-//! It seems [metrics-process-promstyle][] only support Linux but this crate (metrics-process) supports Linux, macOS, and Windows.
-//! Additionally, this crate supports `process_open_fds` and `process_max_fds` addition to what metrics-process-promstyle supports.
-//!
-//! [metrics-process-promstyle]: https://crates.io/crates/metrics-process-promstyle
+#![doc = include_str!("../README.md")]
+
 mod collector;
 
 use metrics::{describe_gauge, gauge, Unit};
@@ -103,11 +7,18 @@ use metrics::{describe_gauge, gauge, Unit};
 /// Prometheus style process metrics collector
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Collector {
-    prefix: String,
+    cpu_seconds_total: &'static str,
+    open_fds: &'static str,
+    max_fds: &'static str,
+    virtual_memory_bytes: &'static str,
+    virtual_memory_max_bytes: &'static str,
+    resident_memory_bytes: &'static str,
+    start_time_seconds: &'static str,
+    threads: &'static str,
 }
 
 impl Default for Collector {
-    /// Create a new Collector instance
+    /// Create a new Collector instance without prefix.
     ///
     /// # Examples
     ///
@@ -116,7 +27,16 @@ impl Default for Collector {
     /// let collector = Collector::default();
     /// ```
     fn default() -> Self {
-        Self { prefix: "".into() }
+        Self {
+            cpu_seconds_total: "process_cpu_seconds_total",
+            open_fds: "process_open_fds",
+            max_fds: "process_max_fds",
+            virtual_memory_bytes: "process_virtual_memory_bytes",
+            virtual_memory_max_bytes: "process_virtual_memory_max_bytes",
+            resident_memory_bytes: "process_resident_memory_bytes",
+            start_time_seconds: "process_start_time_seconds",
+            threads: "process_threads",
+        }
     }
 }
 
@@ -126,11 +46,20 @@ impl Collector {
     ///
     /// ```
     /// # use metrics_process::Collector;
-    /// let collector = Collector::default().prefix("my_prefix_");
+    /// let collector = Collector::new("my_prefix_");
     /// ```
-    pub fn prefix(mut self, prefix: impl Into<String>) -> Self {
-        self.prefix = prefix.into();
-        self
+    pub fn new(prefix: impl AsRef<str>) -> Self {
+        let prefix = prefix.as_ref();
+        Self {
+            cpu_seconds_total: format!("{prefix}process_cpu_seconds_total").leak(),
+            open_fds: format!("{prefix}process_open_fds").leak(),
+            max_fds: format!("{prefix}process_max_fds").leak(),
+            virtual_memory_bytes: format!("{prefix}process_virtual_memory_bytes").leak(),
+            virtual_memory_max_bytes: format!("{prefix}process_virtual_memory_max_bytes").leak(),
+            resident_memory_bytes: format!("{prefix}process_resident_memory_bytes").leak(),
+            start_time_seconds: format!("{prefix}process_start_time_seconds").leak(),
+            threads: format!("{prefix}process_threads").leak(),
+        }
     }
 
     /// Describe available metrics through `describe_gauge!` macro of `metrics` crate.
@@ -152,46 +81,45 @@ impl Collector {
     /// # }
     /// ```
     pub fn describe(&self) {
-        let prefix = &self.prefix;
         describe_gauge!(
-            format!("{}process_cpu_seconds_total", prefix),
+            self.cpu_seconds_total,
             Unit::Seconds,
             "Total user and system CPU time spent in seconds."
         );
         describe_gauge!(
-            format!("{}process_open_fds", prefix),
+            self.open_fds,
             Unit::Count,
             "Number of open file descriptors."
         );
         describe_gauge!(
-            format!("{}process_max_fds", prefix),
+            self.max_fds,
             Unit::Count,
             "Maximum number of open file descriptors."
         );
         describe_gauge!(
-            format!("{}process_virtual_memory_bytes", prefix),
+            self.virtual_memory_bytes,
             Unit::Bytes,
             "Virtual memory size in bytes."
         );
         #[cfg(not(target_os = "windows"))]
         describe_gauge!(
-            format!("{}process_virtual_memory_max_bytes", prefix),
+            self.virtual_memory_max_bytes,
             Unit::Bytes,
             "Maximum amount of virtual memory available in bytes."
         );
         describe_gauge!(
-            format!("{}process_resident_memory_bytes", prefix),
+            self.resident_memory_bytes,
             Unit::Bytes,
             "Resident memory size in bytes."
         );
         describe_gauge!(
-            format!("{}process_start_time_seconds", prefix),
+            self.start_time_seconds,
             Unit::Seconds,
             "Start time of the process since unix epoch in seconds."
         );
         #[cfg(not(target_os = "windows"))]
         describe_gauge!(
-            format!("{}process_threads", prefix),
+            self.threads,
             Unit::Count,
             "Number of OS threads in the process."
         );
@@ -217,36 +145,32 @@ impl Collector {
     /// # }
     /// ```
     pub fn collect(&self) {
-        let prefix = &self.prefix;
         let mut m = collector::collect();
         if let Some(v) = m.cpu_seconds_total.take() {
-            gauge!(format!("{}process_cpu_seconds_total", prefix), v);
+            gauge!(self.cpu_seconds_total).set(v as f64);
         }
         if let Some(v) = m.open_fds.take() {
-            gauge!(format!("{}process_open_fds", prefix), v as f64);
+            gauge!(self.open_fds).set(v as f64);
         }
         if let Some(v) = m.max_fds.take() {
-            gauge!(format!("{}process_max_fds", prefix), v as f64);
+            gauge!(self.max_fds).set(v as f64);
         }
         if let Some(v) = m.virtual_memory_bytes.take() {
-            gauge!(format!("{}process_virtual_memory_bytes", prefix), v as f64);
+            gauge!(self.virtual_memory_bytes).set(v as f64);
         }
         #[cfg(not(target_os = "windows"))]
         if let Some(v) = m.virtual_memory_max_bytes.take() {
-            gauge!(
-                format!("{}process_virtual_memory_max_bytes", prefix),
-                v as f64,
-            );
+            gauge!(self.virtual_memory_max_bytes).set(v as f64);
         }
         if let Some(v) = m.resident_memory_bytes.take() {
-            gauge!(format!("{}process_resident_memory_bytes", prefix), v as f64);
+            gauge!(self.resident_memory_bytes).set(v as f64);
         }
         if let Some(v) = m.start_time_seconds.take() {
-            gauge!(format!("{}process_start_time_seconds", prefix), v as f64);
+            gauge!(self.start_time_seconds).set(v as f64);
         }
         #[cfg(not(target_os = "windows"))]
         if let Some(v) = m.threads.take() {
-            gauge!(format!("{}process_threads", prefix), v as f64);
+            gauge!(self.threads).set(v as f64);
         }
     }
 }


### PR DESCRIPTION
Updated:

- `metrics` to 0.22
- `metrics-exporter-prometheus` to 0.13
- Reduced allocations in `describe` & `collect`. Collector now takes a `prefix` upon it's instantiation, builds the strings for metrics names and reuses them onward. No need to allocate new string each time.

This is a breaking change due to removal of `Collector::prefix` method. Though it can be brought back, but I don't think there is much use cases for that. 

Additionally:
- I've replaced the doc string in `lib.rs` with `include_str!("../README.md")` so that it stays updated. But I've notices the `README.tpl` file, it seems you are generating the `README` from the `lib.rs` docs? If you'll accept my proposal (with `include_str`), the `tpl` file could be deleted.
- I've removed redundant `[]` in the markdown links, not sure why they were there.
- I've removed `Diff check` step from the `fmt` job, there is a `--check` flag in `cargo-fmt` that does that?

Supersedes #32, #33.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Updated the testing workflow for improved code format verification.
	- Streamlined the `Collector` struct for enhanced metrics handling.

- **Documentation**
	- Improved the formatting of URLs and code examples in the main README.
	- Refined the presentation of crate references in example READMEs.

- **Chores**
	- Removed unnecessary brackets in documentation links for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->