### PR TITLE
Reduce allocations in Collector

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@
 
 mod collector;
 
-use std::{mem, sync::Arc};
+use std::sync::Arc;
 
 use metrics::{describe_gauge, gauge, Unit};
 
@@ -116,9 +116,9 @@ struct Metrics {
 
 impl Metrics {
     // Create new Metrics, allocating prefixed strings for metrics names.
-    fn new(prefix: impl AsRef<str>) -> Arc<Self> {
+    fn new(prefix: impl AsRef<str>) -> Self {
         let prefix = prefix.as_ref();
-        Arc::new(Self {
+        Self {
             cpu_seconds_total: format!("{prefix}process_cpu_seconds_total").into(),
             open_fds: format!("{prefix}process_open_fds").into(),
             max_fds: format!("{prefix}process_max_fds").into(),
@@ -127,23 +127,14 @@ impl Metrics {
             resident_memory_bytes: format!("{prefix}process_resident_memory_bytes").into(),
             start_time_seconds: format!("{prefix}process_start_time_seconds").into(),
             threads: format!("{prefix}process_threads").into(),
-        })
+        }
     }
 }
 
 impl Default for Metrics {
     // Create new Metrics, without prefixing and thus allocating.
     fn default() -> Self {
-        Self {
-            cpu_seconds_total: "process_cpu_seconds_total".into(),
-            open_fds: "process_open_fds".into(),
-            max_fds: "process_max_fds".into(),
-            virtual_memory_bytes: "process_virtual_memory_bytes".into(),
-            virtual_memory_max_bytes: "process_virtual_memory_max_bytes".into(),
-            resident_memory_bytes: "process_resident_memory_bytes".into(),
-            start_time_seconds: "process_start_time_seconds".into(),
-            threads: "process_threads".into(),
-        }
+        Self::new("")
     }
 }
 
@@ -154,7 +145,8 @@ pub struct Collector {
 }
 
 impl Default for Collector {
-    /// Create a new Collector instance without prefix.
+    /// Create a new Collector instance without prefix. This is the same as
+    /// calling `Collector::new` with an empty string for prefix.
     ///
     /// # Examples
     ///
@@ -177,6 +169,16 @@ impl Collector {
     /// # use metrics_process::Collector;
     /// let collector = Collector::default().prefix("my_prefix_");
     /// ```
+    ///
+    /// # Deprecated
+    ///
+    /// The new interface for creating a Collector should be utilized.
+    ///
+    /// ```
+    /// # use metrics_process::Collector;
+    /// let collector = Collector::new("my_prefix_");
+    /// ```
+    #[deprecated(since = "1.1.0", note = "Use `Collector::new(prefix)`.")]
     pub fn prefix(self, prefix: impl Into<String>) -> Self {
         drop(self);
         Self::new(prefix.into())
@@ -193,7 +195,7 @@ impl Collector {
     /// ```
     pub fn new(prefix: impl AsRef<str>) -> Self {
         Self {
-            metrics: Metrics::new(prefix),
+            metrics: Arc::new(Metrics::new(prefix)),
         }
     }
 
@@ -219,44 +221,44 @@ impl Collector {
         let metrics = self.metrics.as_ref();
 
         describe_gauge!(
-            metrics.cpu_seconds_total.clone(),
+            Arc::clone(&metrics.cpu_seconds_total),
             Unit::Seconds,
             "Total user and system CPU time spent in seconds."
         );
         describe_gauge!(
-            metrics.open_fds.clone(),
+            Arc::clone(&metrics.open_fds),
             Unit::Count,
             "Number of open file descriptors."
         );
         describe_gauge!(
-            metrics.max_fds.clone(),
+            Arc::clone(&metrics.max_fds),
             Unit::Count,
             "Maximum number of open file descriptors."
         );
         describe_gauge!(
-            metrics.virtual_memory_bytes.clone(),
+            Arc::clone(&metrics.virtual_memory_bytes),
             Unit::Bytes,
             "Virtual memory size in bytes."
         );
         #[cfg(not(target_os = "windows"))]
         describe_gauge!(
-            metrics.virtual_memory_max_bytes.clone(),
+            Arc::clone(&metrics.virtual_memory_max_bytes),
             Unit::Bytes,
             "Maximum amount of virtual memory available in bytes."
         );
         describe_gauge!(
-            metrics.resident_memory_bytes.clone(),
+            Arc::clone(&metrics.resident_memory_bytes),
             Unit::Bytes,
             "Resident memory size in bytes."
         );
         describe_gauge!(
-            metrics.start_time_seconds.clone(),
+            Arc::clone(&metrics.start_time_seconds),
             Unit::Seconds,
             "Start time of the process since unix epoch in seconds."
         );
         #[cfg(not(target_os = "windows"))]
         describe_gauge!(
-            metrics.threads.clone(),
+            Arc::clone(&metrics.threads),
             Unit::Count,
             "Number of OS threads in the process."
         );
@@ -285,30 +287,30 @@ impl Collector {
         let metrics = self.metrics.as_ref();
         let mut m = collector::collect();
         if let Some(v) = m.cpu_seconds_total.take() {
-            gauge!(metrics.cpu_seconds_total.clone()).set(v);
+            gauge!(Arc::clone(&metrics.cpu_seconds_total)).set(v);
         }
         if let Some(v) = m.open_fds.take() {
-            gauge!(metrics.open_fds.clone()).set(v as f64);
+            gauge!(Arc::clone(&metrics.open_fds)).set(v as f64);
         }
         if let Some(v) = m.max_fds.take() {
-            gauge!(metrics.max_fds.clone()).set(v as f64);
+            gauge!(Arc::clone(&metrics.max_fds)).set(v as f64);
         }
         if let Some(v) = m.virtual_memory_bytes.take() {
-            gauge!(metrics.virtual_memory_bytes.clone()).set(v as f64);
+            gauge!(Arc::clone(&metrics.virtual_memory_bytes)).set(v as f64);
         }
         #[cfg(not(target_os = "windows"))]
         if let Some(v) = m.virtual_memory_max_bytes.take() {
-            gauge!(metrics.virtual_memory_max_bytes.clone()).set(v as f64);
+            gauge!(Arc::clone(&metrics.virtual_memory_max_bytes)).set(v as f64);
         }
         if let Some(v) = m.resident_memory_bytes.take() {
-            gauge!(metrics.resident_memory_bytes.clone()).set(v as f64);
+            gauge!(Arc::clone(&metrics.resident_memory_bytes)).set(v as f64);
         }
         if let Some(v) = m.start_time_seconds.take() {
-            gauge!(metrics.start_time_seconds.clone()).set(v as f64);
+            gauge!(Arc::clone(&metrics.start_time_seconds)).set(v as f64);
         }
         #[cfg(not(target_os = "windows"))]
         if let Some(v) = m.threads.take() {
-            gauge!(metrics.threads.clone()).set(v as f64);
+            gauge!(Arc::clone(&metrics.threads)).set(v as f64);
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,35 +104,29 @@ use metrics::{describe_gauge, gauge, Unit};
 /// Metrics names
 #[derive(Debug, PartialEq, Eq)]
 struct Metrics {
-    prefixed: bool,
-    cpu_seconds_total: &'static str,
-    open_fds: &'static str,
-    max_fds: &'static str,
-    virtual_memory_bytes: &'static str,
-    virtual_memory_max_bytes: &'static str,
-    resident_memory_bytes: &'static str,
-    start_time_seconds: &'static str,
-    threads: &'static str,
+    cpu_seconds_total: Arc<str>,
+    open_fds: Arc<str>,
+    max_fds: Arc<str>,
+    virtual_memory_bytes: Arc<str>,
+    virtual_memory_max_bytes: Arc<str>,
+    resident_memory_bytes: Arc<str>,
+    start_time_seconds: Arc<str>,
+    threads: Arc<str>,
 }
 
 impl Metrics {
     // Create new Metrics, allocating prefixed strings for metrics names.
     fn new(prefix: impl AsRef<str>) -> Arc<Self> {
-        fn prefixed(prefix: &str, name: &str) -> &'static str {
-            Box::leak(format!("{prefix}{name}").into_boxed_str())
-        }
-
         let prefix = prefix.as_ref();
         Arc::new(Self {
-            prefixed: true,
-            cpu_seconds_total: prefixed(prefix, "process_cpu_seconds_total"),
-            open_fds: prefixed(prefix, "process_open_fds"),
-            max_fds: prefixed(prefix, "process_max_fds"),
-            virtual_memory_bytes: prefixed(prefix, "process_virtual_memory_bytes"),
-            virtual_memory_max_bytes: prefixed(prefix, "process_virtual_memory_max_bytes"),
-            resident_memory_bytes: prefixed(prefix, "process_resident_memory_bytes"),
-            start_time_seconds: prefixed(prefix, "process_start_time_seconds"),
-            threads: prefixed(prefix, "process_threads"),
+            cpu_seconds_total: format!("{prefix}process_cpu_seconds_total").into(),
+            open_fds: format!("{prefix}process_open_fds").into(),
+            max_fds: format!("{prefix}process_max_fds").into(),
+            virtual_memory_bytes: format!("{prefix}process_virtual_memory_bytes").into(),
+            virtual_memory_max_bytes: format!("{prefix}process_virtual_memory_max_bytes").into(),
+            resident_memory_bytes: format!("{prefix}process_resident_memory_bytes").into(),
+            start_time_seconds: format!("{prefix}process_start_time_seconds").into(),
+            threads: format!("{prefix}process_threads").into(),
         })
     }
 }
@@ -141,62 +135,14 @@ impl Default for Metrics {
     // Create new Metrics, without prefixing and thus allocating.
     fn default() -> Self {
         Self {
-            prefixed: false,
-            cpu_seconds_total: "process_cpu_seconds_total",
-            open_fds: "process_open_fds",
-            max_fds: "process_max_fds",
-            virtual_memory_bytes: "process_virtual_memory_bytes",
-            virtual_memory_max_bytes: "process_virtual_memory_max_bytes",
-            resident_memory_bytes: "process_resident_memory_bytes",
-            start_time_seconds: "process_start_time_seconds",
-            threads: "process_threads",
-        }
-    }
-}
-
-impl Drop for Metrics {
-    fn drop(&mut self) {
-        unsafe fn drop_static_str(s: &'static str) {
-            let ptr: *const str = s;
-            let ptr = ptr.cast_mut();
-            let boxed = unsafe { Box::from_raw(ptr) };
-            drop(boxed);
-        }
-
-        // If the strings are not prefixed, we must not deallocate them, as they
-        // are literals from `Default` implementation.
-        if !self.prefixed {
-            return;
-        }
-
-        // Get self by value from mutable reference
-        let this = mem::take(self);
-
-        // Copy all pointers
-        let cpu_seconds_total = this.cpu_seconds_total;
-        let open_fds = this.open_fds;
-        let max_fds = this.max_fds;
-        let virtual_memory_bytes = this.virtual_memory_bytes;
-        let virtual_memory_max_bytes = this.virtual_memory_max_bytes;
-        let resident_memory_bytes = this.resident_memory_bytes;
-        let start_time_seconds = this.start_time_seconds;
-        let threads = this.threads;
-
-        // Prevent recursive drop
-        mem::forget(this);
-
-        // SAFETY: We've checked that those `&'static str`s are the ones we
-        //         allocated. They are not exposed publicly, are created by
-        //         `Box::leak`, and we're deallocating them only once.
-        unsafe {
-            drop_static_str(cpu_seconds_total);
-            drop_static_str(open_fds);
-            drop_static_str(max_fds);
-            drop_static_str(virtual_memory_bytes);
-            drop_static_str(virtual_memory_max_bytes);
-            drop_static_str(resident_memory_bytes);
-            drop_static_str(start_time_seconds);
-            drop_static_str(threads);
+            cpu_seconds_total: "process_cpu_seconds_total".into(),
+            open_fds: "process_open_fds".into(),
+            max_fds: "process_max_fds".into(),
+            virtual_memory_bytes: "process_virtual_memory_bytes".into(),
+            virtual_memory_max_bytes: "process_virtual_memory_max_bytes".into(),
+            resident_memory_bytes: "process_resident_memory_bytes".into(),
+            start_time_seconds: "process_start_time_seconds".into(),
+            threads: "process_threads".into(),
         }
     }
 }
@@ -273,44 +219,44 @@ impl Collector {
         let metrics = self.metrics.as_ref();
 
         describe_gauge!(
-            metrics.cpu_seconds_total,
+            metrics.cpu_seconds_total.clone(),
             Unit::Seconds,
             "Total user and system CPU time spent in seconds."
         );
         describe_gauge!(
-            metrics.open_fds,
+            metrics.open_fds.clone(),
             Unit::Count,
             "Number of open file descriptors."
         );
         describe_gauge!(
-            metrics.max_fds,
+            metrics.max_fds.clone(),
             Unit::Count,
             "Maximum number of open file descriptors."
         );
         describe_gauge!(
-            metrics.virtual_memory_bytes,
+            metrics.virtual_memory_bytes.clone(),
             Unit::Bytes,
             "Virtual memory size in bytes."
         );
         #[cfg(not(target_os = "windows"))]
         describe_gauge!(
-            metrics.virtual_memory_max_bytes,
+            metrics.virtual_memory_max_bytes.clone(),
             Unit::Bytes,
             "Maximum amount of virtual memory available in bytes."
         );
         describe_gauge!(
-            metrics.resident_memory_bytes,
+            metrics.resident_memory_bytes.clone(),
             Unit::Bytes,
             "Resident memory size in bytes."
         );
         describe_gauge!(
-            metrics.start_time_seconds,
+            metrics.start_time_seconds.clone(),
             Unit::Seconds,
             "Start time of the process since unix epoch in seconds."
         );
         #[cfg(not(target_os = "windows"))]
         describe_gauge!(
-            metrics.threads,
+            metrics.threads.clone(),
             Unit::Count,
             "Number of OS threads in the process."
         );
@@ -339,30 +285,30 @@ impl Collector {
         let metrics = self.metrics.as_ref();
         let mut m = collector::collect();
         if let Some(v) = m.cpu_seconds_total.take() {
-            gauge!(metrics.cpu_seconds_total).set(v);
+            gauge!(metrics.cpu_seconds_total.clone()).set(v);
         }
         if let Some(v) = m.open_fds.take() {
-            gauge!(metrics.open_fds).set(v as f64);
+            gauge!(metrics.open_fds.clone()).set(v as f64);
         }
         if let Some(v) = m.max_fds.take() {
-            gauge!(metrics.max_fds).set(v as f64);
+            gauge!(metrics.max_fds.clone()).set(v as f64);
         }
         if let Some(v) = m.virtual_memory_bytes.take() {
-            gauge!(metrics.virtual_memory_bytes).set(v as f64);
+            gauge!(metrics.virtual_memory_bytes.clone()).set(v as f64);
         }
         #[cfg(not(target_os = "windows"))]
         if let Some(v) = m.virtual_memory_max_bytes.take() {
-            gauge!(metrics.virtual_memory_max_bytes).set(v as f64);
+            gauge!(metrics.virtual_memory_max_bytes.clone()).set(v as f64);
         }
         if let Some(v) = m.resident_memory_bytes.take() {
-            gauge!(metrics.resident_memory_bytes).set(v as f64);
+            gauge!(metrics.resident_memory_bytes.clone()).set(v as f64);
         }
         if let Some(v) = m.start_time_seconds.take() {
-            gauge!(metrics.start_time_seconds).set(v as f64);
+            gauge!(metrics.start_time_seconds.clone()).set(v as f64);
         }
         #[cfg(not(target_os = "windows"))]
         if let Some(v) = m.threads.take() {
-            gauge!(metrics.threads).set(v as f64);
+            gauge!(metrics.threads.clone()).set(v as f64);
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,16 +97,118 @@
 
 mod collector;
 
+use std::{mem, sync::Arc};
+
 use metrics::{describe_gauge, gauge, Unit};
+
+/// Metrics names
+#[derive(Debug, PartialEq, Eq)]
+struct Metrics {
+    prefixed: bool,
+    cpu_seconds_total: &'static str,
+    open_fds: &'static str,
+    max_fds: &'static str,
+    virtual_memory_bytes: &'static str,
+    virtual_memory_max_bytes: &'static str,
+    resident_memory_bytes: &'static str,
+    start_time_seconds: &'static str,
+    threads: &'static str,
+}
+
+impl Metrics {
+    // Create new Metrics, allocating prefixed strings for metrics names.
+    fn new(prefix: impl AsRef<str>) -> Arc<Self> {
+        fn prefixed(prefix: &str, name: &str) -> &'static str {
+            Box::leak(format!("{prefix}{name}").into_boxed_str())
+        }
+
+        let prefix = prefix.as_ref();
+        Arc::new(Self {
+            prefixed: true,
+            cpu_seconds_total: prefixed(prefix, "process_cpu_seconds_total"),
+            open_fds: prefixed(prefix, "process_open_fds"),
+            max_fds: prefixed(prefix, "process_max_fds"),
+            virtual_memory_bytes: prefixed(prefix, "process_virtual_memory_bytes"),
+            virtual_memory_max_bytes: prefixed(prefix, "process_virtual_memory_max_bytes"),
+            resident_memory_bytes: prefixed(prefix, "process_resident_memory_bytes"),
+            start_time_seconds: prefixed(prefix, "process_start_time_seconds"),
+            threads: prefixed(prefix, "process_threads"),
+        })
+    }
+}
+
+impl Default for Metrics {
+    // Create new Metrics, without prefixing and thus allocating.
+    fn default() -> Self {
+        Self {
+            prefixed: false,
+            cpu_seconds_total: "process_cpu_seconds_total",
+            open_fds: "process_open_fds",
+            max_fds: "process_max_fds",
+            virtual_memory_bytes: "process_virtual_memory_bytes",
+            virtual_memory_max_bytes: "process_virtual_memory_max_bytes",
+            resident_memory_bytes: "process_resident_memory_bytes",
+            start_time_seconds: "process_start_time_seconds",
+            threads: "process_threads",
+        }
+    }
+}
+
+impl Drop for Metrics {
+    fn drop(&mut self) {
+        unsafe fn drop_static_str(s: &'static str) {
+            let ptr: *const str = s;
+            let ptr = ptr.cast_mut();
+            let boxed = unsafe { Box::from_raw(ptr) };
+            drop(boxed);
+        }
+
+        // If the strings are not prefixed, we must not deallocate them, as they
+        // are literals from `Default` implementation.
+        if !self.prefixed {
+            return;
+        }
+
+        // Get self by value from mutable reference
+        let this = mem::take(self);
+
+        // Copy all pointers
+        let cpu_seconds_total = this.cpu_seconds_total;
+        let open_fds = this.open_fds;
+        let max_fds = this.max_fds;
+        let virtual_memory_bytes = this.virtual_memory_bytes;
+        let virtual_memory_max_bytes = this.virtual_memory_max_bytes;
+        let resident_memory_bytes = this.resident_memory_bytes;
+        let start_time_seconds = this.start_time_seconds;
+        let threads = this.threads;
+
+        // Prevent recursive drop
+        mem::forget(this);
+
+        // SAFETY: We've checked that those `&'static str`s are the ones we
+        //         allocated. They are not exposed publicly, are created by
+        //         `Box::leak`, and we're deallocating them only once.
+        unsafe {
+            drop_static_str(cpu_seconds_total);
+            drop_static_str(open_fds);
+            drop_static_str(max_fds);
+            drop_static_str(virtual_memory_bytes);
+            drop_static_str(virtual_memory_max_bytes);
+            drop_static_str(resident_memory_bytes);
+            drop_static_str(start_time_seconds);
+            drop_static_str(threads);
+        }
+    }
+}
 
 /// Prometheus style process metrics collector
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Collector {
-    prefix: String,
+    metrics: Arc<Metrics>,
 }
 
 impl Default for Collector {
-    /// Create a new Collector instance
+    /// Create a new Collector instance without prefix.
     ///
     /// # Examples
     ///
@@ -115,7 +217,9 @@ impl Default for Collector {
     /// let collector = Collector::default();
     /// ```
     fn default() -> Self {
-        Self { prefix: "".into() }
+        Self {
+            metrics: Arc::default(),
+        }
     }
 }
 
@@ -127,9 +231,24 @@ impl Collector {
     /// # use metrics_process::Collector;
     /// let collector = Collector::default().prefix("my_prefix_");
     /// ```
-    pub fn prefix(mut self, prefix: impl Into<String>) -> Self {
-        self.prefix = prefix.into();
-        self
+    pub fn prefix(self, prefix: impl Into<String>) -> Self {
+        drop(self);
+        Self::new(prefix.into())
+    }
+
+    /// Create a new Collector instance with the provided prefix that is
+    /// prepended to metric keys.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use metrics_process::Collector;
+    /// let collector = Collector::default();
+    /// ```
+    pub fn new(prefix: impl AsRef<str>) -> Self {
+        Self {
+            metrics: Metrics::new(prefix),
+        }
     }
 
     /// Describe available metrics through `describe_gauge!` macro of `metrics` crate.
@@ -151,46 +270,47 @@ impl Collector {
     /// # }
     /// ```
     pub fn describe(&self) {
-        let prefix = &self.prefix;
+        let metrics = self.metrics.as_ref();
+
         describe_gauge!(
-            format!("{}process_cpu_seconds_total", prefix),
+            metrics.cpu_seconds_total,
             Unit::Seconds,
             "Total user and system CPU time spent in seconds."
         );
         describe_gauge!(
-            format!("{}process_open_fds", prefix),
+            metrics.open_fds,
             Unit::Count,
             "Number of open file descriptors."
         );
         describe_gauge!(
-            format!("{}process_max_fds", prefix),
+            metrics.max_fds,
             Unit::Count,
             "Maximum number of open file descriptors."
         );
         describe_gauge!(
-            format!("{}process_virtual_memory_bytes", prefix),
+            metrics.virtual_memory_bytes,
             Unit::Bytes,
             "Virtual memory size in bytes."
         );
         #[cfg(not(target_os = "windows"))]
         describe_gauge!(
-            format!("{}process_virtual_memory_max_bytes", prefix),
+            metrics.virtual_memory_max_bytes,
             Unit::Bytes,
             "Maximum amount of virtual memory available in bytes."
         );
         describe_gauge!(
-            format!("{}process_resident_memory_bytes", prefix),
+            metrics.resident_memory_bytes,
             Unit::Bytes,
             "Resident memory size in bytes."
         );
         describe_gauge!(
-            format!("{}process_start_time_seconds", prefix),
+            metrics.start_time_seconds,
             Unit::Seconds,
             "Start time of the process since unix epoch in seconds."
         );
         #[cfg(not(target_os = "windows"))]
         describe_gauge!(
-            format!("{}process_threads", prefix),
+            metrics.threads,
             Unit::Count,
             "Number of OS threads in the process."
         );
@@ -216,33 +336,33 @@ impl Collector {
     /// # }
     /// ```
     pub fn collect(&self) {
-        let prefix = &self.prefix;
+        let metrics = self.metrics.as_ref();
         let mut m = collector::collect();
         if let Some(v) = m.cpu_seconds_total.take() {
-            gauge!(format!("{}process_cpu_seconds_total", prefix)).set(v);
+            gauge!(metrics.cpu_seconds_total).set(v);
         }
         if let Some(v) = m.open_fds.take() {
-            gauge!(format!("{}process_open_fds", prefix)).set(v as f64);
+            gauge!(metrics.open_fds).set(v as f64);
         }
         if let Some(v) = m.max_fds.take() {
-            gauge!(format!("{}process_max_fds", prefix)).set(v as f64);
+            gauge!(metrics.max_fds).set(v as f64);
         }
         if let Some(v) = m.virtual_memory_bytes.take() {
-            gauge!(format!("{}process_virtual_memory_bytes", prefix)).set(v as f64);
+            gauge!(metrics.virtual_memory_bytes).set(v as f64);
         }
         #[cfg(not(target_os = "windows"))]
         if let Some(v) = m.virtual_memory_max_bytes.take() {
-            gauge!(format!("{}process_virtual_memory_max_bytes", prefix)).set(v as f64);
+            gauge!(metrics.virtual_memory_max_bytes).set(v as f64);
         }
         if let Some(v) = m.resident_memory_bytes.take() {
-            gauge!(format!("{}process_resident_memory_bytes", prefix)).set(v as f64);
+            gauge!(metrics.resident_memory_bytes).set(v as f64);
         }
         if let Some(v) = m.start_time_seconds.take() {
-            gauge!(format!("{}process_start_time_seconds", prefix)).set(v as f64);
+            gauge!(metrics.start_time_seconds).set(v as f64);
         }
         #[cfg(not(target_os = "windows"))]
         if let Some(v) = m.threads.take() {
-            gauge!(format!("{}process_threads", prefix)).set(v as f64);
+            gauge!(metrics.threads).set(v as f64);
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,26 +139,9 @@ impl Default for Metrics {
 }
 
 /// Prometheus style process metrics collector
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
 pub struct Collector {
     metrics: Arc<Metrics>,
-}
-
-impl Default for Collector {
-    /// Create a new Collector instance without prefix. This is the same as
-    /// calling `Collector::new` with an empty string for prefix.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use metrics_process::Collector;
-    /// let collector = Collector::default();
-    /// ```
-    fn default() -> Self {
-        Self {
-            metrics: Arc::default(),
-        }
-    }
 }
 
 impl Collector {
@@ -180,7 +163,7 @@ impl Collector {
     /// ```
     #[deprecated(since = "1.1.0", note = "Use `Collector::new(prefix)`.")]
     pub fn prefix(self, prefix: impl Into<String>) -> Self {
-        drop(self);
+        let _ = self;
         Self::new(prefix.into())
     }
 


### PR DESCRIPTION
From [this](https://github.com/lambdalisue/rs-metrics-process/pull/34#discussion_r1436402430) discussion:

_Originally posted by @lambdalisue in https://github.com/lambdalisue/rs-metrics-process/pull/34#discussion_r1436402430_:

> I don't think it's good idea to use `leak()` here.

_Originally posted by @zohnannor in https://github.com/lambdalisue/rs-metrics-process/pull/34#discussion_r1436410565_:

> This way we are allocating the `String` only once, and then reuse it in `gauge!()` macros for metrics names. The `&'static str` also helps -- it unties the lifetime from the `&self` reference.
> 
> The only downside of `leak`ing is that the data of `String`s allocated won't be freed until the program exits. In a contrived scenario, where one creates a ton of `Collectors` with `prefix` provided and then drops them this would cause problems. But from my understanding, the `Collector` is meant to be created once at the start and used for the entire runtime of the program.
> 
> Still, we can counter this by `Box::leak`ing the strings allocated and then giving the `Collector` the `Drop` `impl` that will `unsafe`ly `Box::from_raw` them to drop properly. If you're fine with that, I'll implement this in differend PR.

_Originally posted by @lambdalisue in https://github.com/lambdalisue/rs-metrics-process/pull/34#discussion_r1436764514_:
            
> How about utilizing `String` to store each label instead of `&'static str` in `Collectors`? I'm asking because the advantages of using `&'static str` in `Collectors` are not clear to me. Is there a significant difference in memory usage or any other factors to consider?

            

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new `Metrics` management system to enhance metric tracking.

- **Refactor**
  - Improved the `Collector` component to utilize the new `Metrics` system for more efficient metric collection and handling.

- **Documentation**
  - Updated triage instructions to align with the new metric management features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->