### PR TITLE
:boom: Utilize the Counter for `process_cpu_seconds_total` metrics instead of Gauge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Test
         run: |
           cargo build --release --all-features
+      - name: Test (use-gauge-on-cpu-seconds-total)
+        run: |
+          cargo build --release --features use-gauge-on-cpu-seconds-total
 
   build-dummy:
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Clippy check
         run: |
           cargo clippy --all-features --all-targets
+      - name: Clippy check (use-gauge-on-cpu-seconds-total)
+        run: |
+          cargo clippy --features use-gauge-on-cpu-seconds-total --all-targets
 
   test:
     strategy:
@@ -91,9 +94,12 @@ jobs:
       - name: Test
         run: |
           cargo llvm-cov --all-features --lcov --output-path lcov.info
+      - name: Test (use-gauge-on-cpu-seconds-total)
+        run: |
+          cargo llvm-cov --features use-gauge-on-cpu-seconds-total --lcov --output-path lcov.use-gauge-on-cpu-seconds-total.info
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: lcov.info
+          files: lcov.info,lcov.use-gauge-on-cpu-seconds-total.info
           env_vars: RUNNER

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,13 @@ description = "Cross-platform Prometheus style process metrics collector of metr
 repository = "https://github.com/lambdalisue/rs-metrics-process"
 license = "MIT"
 readme = "README.md"
-keywords = [ "cross-platform", "metrics", "prometheus", "open-metrics", "process", ]
+keywords = [
+  "cross-platform",
+  "metrics",
+  "prometheus",
+  "open-metrics",
+  "process",
+]
 
 [package.metadata.docs.rs]
 all-features = true
@@ -16,6 +22,10 @@ all-features = true
 [features]
 # Enable a `dummy` collector that always return an empty `Metrics` for non supported platforms
 dummy = []
+# Use a Gauge on `process_cpu_seconds_total` metrics instead of Counter to represent f64 value.
+# This is a previous behavior prior to version 1.3.0.
+# See https://github.com/lambdalisue/rs-metrics-process/issues/44 for more details.
+use-gauge-on-cpu-seconds-total = []
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/README.md
+++ b/README.md
@@ -127,14 +127,6 @@ This crate offers the following features:
 | ------------ | ------------------------------------------------------------------------------------- |
 | `dummy`      | Enables a dummy collector that returns an empty `Metrics` on non-supported platforms. |
 
-## Difference from [metrics-process-promstyle]
-
-It appears that [metrics-process-promstyle] only supports Linux, but this crate
-(metrics-process) supports Linux, macOS, and Windows. Additionally, this crate
-supports `process_open_fds` and `process_max_fds` in addition to what
-metrics-process-promstyle supports.
-
-[metrics-process-promstyle]: https://crates.io/crates/metrics-process-promstyle
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ This crate supports the following metrics provided by [Prometheus] for
 For each platform, it is equivalent to what the official Prometheus client for
 Go ([client_golang]) provides.
 
+> [!NOTE]
+>
+> Prior to version 1.3.0, the `process_cpu_seconds_total` metric was Gauge instead of Counter.
+> Enable `use-gauge-on-cpu-seconds-total` feature to use the previous behavior.
+
 | Metric name                        | Linux | macOS | Windows |
 | ---------------------------------- | ----- | ----- | ------- |
 | `process_cpu_seconds_total`        | x     | x     | x       |
@@ -48,9 +53,10 @@ Go ([client_golang]) provides.
 | `process_start_time_seconds`       | x     | x     | x       |
 | `process_threads`                  | x     | x     |         |
 
-Please note that if you only need to compile this crate on non-supported
-platforms, you can use the `dummy` feature. Enabling this feature activates a
-dummy collector, which returns an empty `Metrics`.
+> [!NOTE]
+>
+> If you only need to compile this crate on non-supported platforms, you can use the `dummy` feature.
+> Enabling this feature activates a dummy collector, which returns an empty `Metrics`.
 
 [client_golang]: https://github.com/prometheus/client_golang
 
@@ -123,10 +129,10 @@ async fn main() {
 
 This crate offers the following features:
 
-| Feature Name | Description                                                                           |
-| ------------ | ------------------------------------------------------------------------------------- |
-| `dummy`      | Enables a dummy collector that returns an empty `Metrics` on non-supported platforms. |
-
+| Feature Name                     | Description                                                                                                                                         |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dummy`                          | Enables a dummy collector that returns an empty `Metrics` on non-supported platforms.                                                               |
+| `use-gauge-on-cpu-seconds-total` | Use a Gauge on `process_cpu_seconds_total` metrics instead of Counter to represent `f64` value. This is a previous behavior prior to version 1.3.0. |
 
 # License
 


### PR DESCRIPTION
Previously, the `process_cpu_seconds_total` metric was a Gauge representing an `f64` value.
However, the corresponding metric in the Prometheus Go client is a Counter.
This change is breaking, so a new feature, `use-gauge-on-cpu-seconds-total`, has been introduced to maintain the previous behavior.

Close https://github.com/lambdalisue/rs-metrics-process/issues/44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced the ability to use a Gauge instead of a Counter for `process_cpu_seconds_total` metrics, with an option to revert to previous behavior.
  
- **Documentation**
	- Updated README to note the change in metric type for `process_cpu_seconds_total` and provided information on reverting to the previous metric type.
	- Enhanced documentation about the `dummy` feature in the crate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->