### PR TITLE
Refer 2.0 instead of 1.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ all-features = true
 # Enable a `dummy` collector that always return an empty `Metrics` for non supported platforms
 dummy = []
 # Use a Gauge on `process_cpu_seconds_total` metrics instead of Counter to represent f64 value.
-# This is a previous behavior prior to version 1.3.0.
+# This is a previous behavior prior to version 2.0.0.
 # See https://github.com/lambdalisue/rs-metrics-process/issues/44 for more details.
 use-gauge-on-cpu-seconds-total = []
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Go ([client_golang]) provides.
 
 > [!NOTE]
 >
-> Prior to version 1.3.0, the `process_cpu_seconds_total` metric was Gauge instead of Counter.
+> Prior to version 2.0.0, the `process_cpu_seconds_total` metric was Gauge instead of Counter.
 > Enable `use-gauge-on-cpu-seconds-total` feature to use the previous behavior.
 
 | Metric name                        | Linux | macOS | Windows |
@@ -132,7 +132,7 @@ This crate offers the following features:
 | Feature Name                     | Description                                                                                                                                         |
 | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `dummy`                          | Enables a dummy collector that returns an empty `Metrics` on non-supported platforms.                                                               |
-| `use-gauge-on-cpu-seconds-total` | Use a Gauge on `process_cpu_seconds_total` metrics instead of Counter to represent `f64` value. This is a previous behavior prior to version 1.3.0. |
+| `use-gauge-on-cpu-seconds-total` | Use a Gauge on `process_cpu_seconds_total` metrics instead of Counter to represent `f64` value. This is a previous behavior prior to version 2.0.0. |
 
 # License
 


### PR DESCRIPTION
See #47 for detail.