### PR TITLE
Add FreeBSD support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,3 +103,25 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info,lcov.use-gauge-on-cpu-seconds-total.info
           env_vars: RUNNER
+
+  test-cross-platform-freebsd:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cross-platform test
+        uses: cross-platform-actions/action@v0.25.0
+        with:
+          operating_system: freebsd
+          version: '14.1'
+          run: |
+            sudo pkg update && sudo pkg install -y rust cmake rust-bindgen-cli
+            cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,9 @@ rlimit = "0.10.0"
 once_cell = "1.13.1"
 procfs = { version = "0.16.0", default-features = false }
 
+[target.'cfg(target_os = "freebsd")'.dependencies]
+libc = "0.2.159"
+
 [target.'cfg(target_os = "windows")'.dependencies.windows]
 version = "0.57.0"
 features = [

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 # ⏱ metrics-process
 
 This crate provides a [Prometheus]-style [process metrics] collector for the
-[metrics] crate, supporting Linux, macOS, Windows, and FreeBSD. The collector
-code is manually rewritten in Rust from the official Prometheus client for Go
-([client_golang]).
+[metrics] crate, supporting Linux, macOS, Windows, and FreeBSD. The original
+collector code was manually rewritten in Rust from the official Prometheus
+client for Go ([client_golang]), FreeBSD support was written from scratch.
 
 [Prometheus]: https://prometheus.io/
 [process metrics]: https://prometheus.io/docs/instrumenting/writing_clientlibs/#process-metrics

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 # ⏱ metrics-process
 
 This crate provides a [Prometheus]-style [process metrics] collector for the
-[metrics] crate, supporting Linux, macOS, and Windows. The collector code is
-manually rewritten in Rust from the official Prometheus client for Go
+[metrics] crate, supporting Linux, macOS, Windows, and FreeBSD. The collector
+code is manually rewritten in Rust from the official Prometheus client for Go
 ([client_golang]).
 
 [Prometheus]: https://prometheus.io/
@@ -41,17 +41,17 @@ Go ([client_golang]) provides.
 > Prior to version 2.0.0, the `process_cpu_seconds_total` metric was Gauge instead of Counter.
 > Enable `use-gauge-on-cpu-seconds-total` feature to use the previous behavior.
 
-| Metric name                        | Linux | macOS | Windows |
-| ---------------------------------- | ----- | ----- | ------- |
-| `process_cpu_seconds_total`        | x     | x     | x       |
-| `process_open_fds`                 | x     | x     | x       |
-| `process_max_fds`                  | x     | x     | x       |
-| `process_virtual_memory_bytes`     | x     | x     | x       |
-| `process_virtual_memory_max_bytes` | x     | x     |         |
-| `process_resident_memory_bytes`    | x     | x     | x       |
-| `process_heap_bytes`               |       |       |         |
-| `process_start_time_seconds`       | x     | x     | x       |
-| `process_threads`                  | x     | x     |         |
+| Metric name                        | Linux | macOS | Windows | FreeBSD |
+| ---------------------------------- | ----- | ----- | ------- | ------- |
+| `process_cpu_seconds_total`        | x     | x     | x       | x       |
+| `process_open_fds`                 | x     | x     | x       | x       |
+| `process_max_fds`                  | x     | x     | x       | x       |
+| `process_virtual_memory_bytes`     | x     | x     | x       | x       |
+| `process_virtual_memory_max_bytes` | x     | x     |         | x       |
+| `process_resident_memory_bytes`    | x     | x     | x       | x       |
+| `process_heap_bytes`               |       |       |         |         |
+| `process_start_time_seconds`       | x     | x     | x       | x       |
+| `process_threads`                  | x     | x     |         | x       |
 
 > [!NOTE]
 >

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -1,13 +1,19 @@
 #[cfg_attr(target_os = "macos", path = "collector/macos.rs")]
 #[cfg_attr(target_os = "linux", path = "collector/linux.rs")]
 #[cfg_attr(target_os = "windows", path = "collector/windows.rs")]
+#[cfg_attr(target_os = "freebsd", path = "collector/freebsd.rs")]
 #[allow(unused_attributes)]
 #[cfg_attr(feature = "dummy", path = "collector/dummy.rs")]
 mod collector;
 
 #[cfg(all(
     not(feature = "dummy"),
-    not(any(target_os = "macos", target_os = "linux", target_os = "windows"))
+    not(any(
+        target_os = "macos",
+        target_os = "linux",
+        target_os = "windows",
+        target_os = "freebsd"
+    ))
 ))]
 compile_error!(
     "A feature \"dummy\" must be enabled to compile this crate on non supported platforms."
@@ -52,7 +58,12 @@ mod tests {
         }
     }
 
-    #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
+    #[cfg(any(
+        target_os = "macos",
+        target_os = "linux",
+        target_os = "windows",
+        target_os = "freebsd"
+    ))]
     #[test]
     fn test_collect_internal_ok() {
         fibonacci(40);
@@ -73,6 +84,7 @@ mod tests {
     #[cfg(not(target_os = "macos"))]
     #[cfg(not(target_os = "linux"))]
     #[cfg(not(target_os = "windows"))]
+    #[cfg(not(target_os = "freebsd"))]
     #[cfg(feature = "dummy")]
     #[test]
     fn test_collect_internal_ok_dummy() {

--- a/src/collector/freebsd.rs
+++ b/src/collector/freebsd.rs
@@ -1,0 +1,112 @@
+use super::Metrics;
+
+fn getrusage(who: libc::c_int) -> Option<libc::rusage> {
+    let mut usage = std::mem::MaybeUninit::zeroed();
+    // SAFETY: libc call; usage is valid pointer to rusage struct
+    if unsafe { libc::getrusage(who, usage.as_mut_ptr()) } == 0 {
+        // SAFETY: libc call was success, struct must be initialized
+        Some(unsafe { usage.assume_init() })
+    } else {
+        None
+    }
+}
+
+fn getrlimit(resource: libc::c_int) -> Option<libc::rlimit> {
+    let mut limit = std::mem::MaybeUninit::zeroed();
+    // SAFETY: libc call; limit is valid pointer to rlimit struct
+    if unsafe { libc::getrlimit(resource, limit.as_mut_ptr()) } == 0 {
+        // SAFETY: libc call was success, struct must be initialized
+        Some(unsafe { limit.assume_init() })
+    } else {
+        None
+    }
+}
+
+fn translate_rlim(rlim: libc::rlim_t) -> u64 {
+    if rlim == libc::RLIM_INFINITY {
+        0
+    } else {
+        rlim as u64
+    }
+}
+
+fn kinfo_getproc(pid: libc::pid_t) -> Option<libc::kinfo_proc> {
+    // References:
+    // kinfo_getproc() code from FreeBSD: https://github.com/freebsd/freebsd-src/blob/b22be3bbb2de75157c97d8baa01ce6cd654caddf/lib/libutil/kinfo_getproc.c
+    // code from deno doing similar stuff: https://github.com/denoland/deno/blob/20ae8db50d7d48ad020b83ebe78dc0e9e9eab3b2/runtime/ops/os/mod.rs#L415
+    let mib = [libc::CTL_KERN, libc::KERN_PROC, libc::KERN_PROC_PID, pid];
+
+    let mut kinfo_proc = std::mem::MaybeUninit::zeroed();
+    let kinfo_proc_size = std::mem::size_of_val(&kinfo_proc) as libc::size_t;
+    let mut data_size = kinfo_proc_size;
+
+    // SAFETY: libc call; mib is statically initialized, kinfo_proc is valid pointer
+    // to kinfo_proc and data_size holds its size
+    if unsafe {
+        libc::sysctl(
+            mib.as_ptr(),
+            mib.len() as _,
+            kinfo_proc.as_mut_ptr() as *mut libc::c_void,
+            &mut data_size,
+            std::ptr::null(),
+            0,
+        )
+    } == 0
+        && data_size == kinfo_proc_size
+    {
+        // SAFETY: libc call was success and check for struct size passed, struct must be initialized
+        Some(unsafe { kinfo_proc.assume_init() })
+    } else {
+        None
+    }
+}
+
+pub fn collect() -> Metrics {
+    let mut metrics = Metrics::default();
+
+    if let Some(usage) = getrusage(libc::RUSAGE_SELF) {
+        metrics.cpu_seconds_total = Some(
+            (usage.ru_utime.tv_sec + usage.ru_stime.tv_sec) as f64
+                + (usage.ru_utime.tv_usec + usage.ru_stime.tv_usec) as f64 / 1000000.0,
+        );
+    }
+
+    if let Some(limit_as) = getrlimit(libc::RLIMIT_AS) {
+        metrics.virtual_memory_max_bytes = Some(translate_rlim(limit_as.rlim_cur));
+    }
+
+    if let Some(limit_as) = getrlimit(libc::RLIMIT_NOFILE) {
+        metrics.max_fds = Some(translate_rlim(limit_as.rlim_cur));
+    }
+
+    // SAFETY: libc call
+    let pid = unsafe { libc::getpid() };
+
+    if let Some(kinfo_proc) = kinfo_getproc(pid) {
+        // struct kinfo_proc layout for reference
+        // libc crate: https://docs.rs/libc/latest/x86_64-unknown-freebsd/libc/struct.kinfo_proc.html
+        // FreeBSD: https://github.com/freebsd/freebsd-src/blob/b22be3bbb2de75157c97d8baa01ce6cd654caddf/lib/libutil/kinfo_getfile.c
+
+        // SAFETY: libc call
+        let pagesize = unsafe { libc::sysconf(libc::_SC_PAGESIZE) } as u64;
+        metrics.virtual_memory_bytes = Some(kinfo_proc.ki_size as u64);
+        metrics.resident_memory_bytes = Some(kinfo_proc.ki_rssize as u64 * pagesize);
+        use std::convert::TryInto as _;
+        metrics.start_time_seconds = kinfo_proc.ki_start.tv_sec.try_into().ok();
+        metrics.threads = kinfo_proc.ki_numthreads.try_into().ok();
+
+        // note that we can't access pointers in kinfo_proc as these point to kernel space
+    }
+
+    // Alternative to this would be implementing kinfo_getfile() like interface, see
+    // https://github.com/freebsd/freebsd-src/blob/b22be3bbb2de75157c97d8baa01ce6cd654caddf/lib/libutil/kinfo_getfile.c
+    // it can be done similar to kinfo_getproc() implementation above, but is more cumbersome
+    // because we have to parse structures of varying size frow raw memory. As long as
+    // it's common to read /proc on Linux, it shuld be as ok to read /dev/fs (which
+    // is roughly the same as /proc/self/fd) on FreeBSD.
+    metrics.open_fds = std::fs::read_dir("/dev/fd")
+        .ok()
+        .map(|read_dir| read_dir.count() as u64);
+
+    metrics
+}


### PR DESCRIPTION
Though FreeBSD does support procfs/linprocfs, these are not required to be mounted (and are commontly not), so use standard always available interfaces instead:

- Take CPU time from getrusage(2)
- Take max open files and max virtual memory size from getrlimit(2)
- Take number of open files from /dev/fd (which is the same as /proc/self/fd on Linux)
- Take remaining fields from kernel process structure retrieved from sysctl(3)

Note that this code may likely be reused for other BSD systems (OpenBSD, NetBSD) with minimal changes.

Example `cargo test -- --nocapture` output on my system:

```
rs-metrics-process% cargo test -- --nocapture
   Compiling metrics-process v2.1.0 (/home/amdmi3/projects/rs-metrics-process)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.21s
     Running unittests src/lib.rs (target/debug/deps/metrics_process-8fe640db94da7b0a)

running 1 test
[src/collector.rs:71:9] &m = Metrics {
    cpu_seconds_total: Some(
        0.632475,
    ),
    open_fds: Some(
        3,
    ),
    max_fds: Some(
        352665,
    ),
    virtual_memory_bytes: Some(
        19263488,
    ),
    virtual_memory_max_bytes: Some(
        0,
    ),
    resident_memory_bytes: Some(
        3719168,
    ),
    start_time_seconds: Some(
        1728493026,
    ),
    threads: Some(
        2,
    ),
}
test collector::tests::test_collect_internal_ok ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.63s

   Doc-tests metrics_process

running 7 tests
test src/lib.rs - Collector::describe (line 96) - compile ... ok
test src/../README.md - (line 69) - compile ... ok
test src/lib.rs - Collector::collect (line 168) - compile ... ok
test src/../README.md - (line 98) - compile ... ok
test src/lib.rs - Collector::prefix (line 67) ... ok
test src/lib.rs - Collector::new (line 82) ... ok
warning: use of deprecated method `metrics_process::Collector::prefix`: Use `Collector::new(prefix)`.
 --> src/lib.rs:61:38
  |
6 | let collector = Collector::default().prefix("my_prefix_");
  |                                      ^^^^^^
  |
  = note: `#[warn(deprecated)]` on by default

warning: 1 warning emitted

test src/lib.rs - Collector::prefix (line 58) ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.11s

```

Notably, after `ulimit -n 100 -v $((1024*1024))`:

```
[src/collector.rs:71:9] &m = Metrics {
    cpu_seconds_total: Some(
        0.631953,
    ),
    open_fds: Some(
        3,
    ),
    max_fds: Some(
        100,
    ),
    virtual_memory_bytes: Some(
        19263488,
    ),
    virtual_memory_max_bytes: Some(
        1073741824,
    ),
    resident_memory_bytes: Some(
        3719168,
    ),
    start_time_seconds: Some(
        1728493170,
    ),
    threads: Some(
        2,
    ),
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced support for FreeBSD operating systems, enabling the collection of system metrics specific to FreeBSD.
	- Added functionality for collecting resource usage and process information on FreeBSD systems.
	- Updated documentation to reflect FreeBSD support, including a metrics availability table.
	- Added a new cross-platform testing job for FreeBSD in the GitHub Actions workflow.

- **Bug Fixes**
	- Updated conditional checks to ensure proper error messaging for unsupported platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->