### PR TITLE
Make CI cache specific to actual build system

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,7 +116,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: freebsd-14.1-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Cross-platform test
         uses: cross-platform-actions/action@v0.25.0
         with:


### PR DESCRIPTION
As suggested by AI in #53 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced cross-platform testing support for FreeBSD.
	- Added a new job specifically for testing on FreeBSD 14.1.

- **Improvements**
	- Enhanced caching mechanism for FreeBSD testing environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->