### PR TITLE
Add OpenBSD support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,8 +104,14 @@ jobs:
           files: lcov.info,lcov.use-gauge-on-cpu-seconds-total.info
           env_vars: RUNNER
 
-  test-cross-platform-freebsd:
+  test-cross-platform:
+    strategy:
+      matrix:
+        # don't forget to update current os versions, see https://github.com/cross-platform-actions/action?tab=readme-ov-file#supported-platforms
+        include:
+          - { os: freebsd, version: "14.1", prepare_cmd: "sudo pkg install -y rust cmake rust-bindgen-cli" }
     runs-on: ubuntu-latest
+    name: "test (${{matrix.os}}-${{matrix.version}})"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4
@@ -116,12 +122,12 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: freebsd-14.1-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{matrix.os}}-${{matrix.version}}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Cross-platform test
         uses: cross-platform-actions/action@v0.25.0
         with:
-          operating_system: freebsd
-          version: '14.1'
+          operating_system: ${{matrix.os}}
+          version: "${{matrix.version}}"
           run: |
-            sudo pkg update && sudo pkg install -y rust cmake rust-bindgen-cli
+            ${{matrix.prepare_cmd}}
             cargo test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,4 +130,4 @@ jobs:
           version: "${{matrix.version}}"
           run: |
             ${{matrix.prepare_cmd}}
-            cargo test
+            cargo test -- --nocapture

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,6 +110,9 @@ jobs:
         # don't forget to update current os versions, see https://github.com/cross-platform-actions/action?tab=readme-ov-file#supported-platforms
         include:
           - { os: freebsd, version: "14.1", prepare_cmd: "sudo pkg install -y rust cmake rust-bindgen-cli" }
+          # 7.6 is not supported by action@v0.25.0 yet
+          - { os: openbsd, version: "7.5", prepare_cmd: "sudo pkg_add rust cmake llvm%17; export LIBCLANG_PATH=/usr/local/llvm17/lib" }
+      fail-fast: false
     runs-on: ubuntu-latest
     name: "test (${{matrix.os}}-${{matrix.version}})"
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,9 @@ procfs = { version = "0.17.0", default-features = false }
 [target.'cfg(target_os = "freebsd")'.dependencies]
 libc = "0.2.159"
 
+[target.'cfg(target_os = "openbsd")'.dependencies]
+libc = "0.2.159"
+
 [target.'cfg(target_os = "windows")'.dependencies.windows]
 version = "0.58.0"
 features = [

--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@
 # ⏱ metrics-process
 
 This crate provides a [Prometheus]-style [process metrics] collector for the
-[metrics] crate, supporting Linux, macOS, Windows, and FreeBSD. The original
-collector code was manually rewritten in Rust from the official Prometheus
-client for Go ([client_golang]), FreeBSD support was written from scratch.
+[metrics] crate, supporting Linux, macOS, Windows, FreeBSD, and OpenBSD. The
+original collector code was manually rewritten in Rust from the official
+Prometheus client for Go ([client_golang]), \*BSD support code was written
+from scratch.
 
 [Prometheus]: https://prometheus.io/
 [process metrics]: https://prometheus.io/docs/instrumenting/writing_clientlibs/#process-metrics
@@ -41,17 +42,17 @@ Go ([client_golang]) provides.
 > Prior to version 2.0.0, the `process_cpu_seconds_total` metric was Gauge instead of Counter.
 > Enable `use-gauge-on-cpu-seconds-total` feature to use the previous behavior.
 
-| Metric name                        | Linux | macOS | Windows | FreeBSD |
-| ---------------------------------- | ----- | ----- | ------- | ------- |
-| `process_cpu_seconds_total`        | x     | x     | x       | x       |
-| `process_open_fds`                 | x     | x     | x       | x       |
-| `process_max_fds`                  | x     | x     | x       | x       |
-| `process_virtual_memory_bytes`     | x     | x     | x       | x       |
-| `process_virtual_memory_max_bytes` | x     | x     |         | x       |
-| `process_resident_memory_bytes`    | x     | x     | x       | x       |
-| `process_heap_bytes`               |       |       |         |         |
-| `process_start_time_seconds`       | x     | x     | x       | x       |
-| `process_threads`                  | x     | x     |         | x       |
+| Metric name                        | Linux | macOS | Windows | FreeBSD | OpenBSD |
+| ---------------------------------- | ----- | ----- | ------- | ------- | ------- |
+| `process_cpu_seconds_total`        | x     | x     | x       | x       | x       |
+| `process_open_fds`                 | x     | x     | x       | x       |         |
+| `process_max_fds`                  | x     | x     | x       | x       | x       |
+| `process_virtual_memory_bytes`     | x     | x     | x       | x       |         |
+| `process_virtual_memory_max_bytes` | x     | x     |         | x       |         |
+| `process_resident_memory_bytes`    | x     | x     | x       | x       | x       |
+| `process_heap_bytes`               |       |       |         |         |         |
+| `process_start_time_seconds`       | x     | x     | x       | x       | x       |
+| `process_threads`                  | x     | x     |         | x       |         |
 
 > [!NOTE]
 >

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -2,6 +2,7 @@
 #[cfg_attr(target_os = "linux", path = "collector/linux.rs")]
 #[cfg_attr(target_os = "windows", path = "collector/windows.rs")]
 #[cfg_attr(target_os = "freebsd", path = "collector/freebsd.rs")]
+#[cfg_attr(target_os = "openbsd", path = "collector/openbsd.rs")]
 #[allow(unused_attributes)]
 #[cfg_attr(feature = "dummy", path = "collector/dummy.rs")]
 mod collector;
@@ -12,7 +13,8 @@ mod collector;
         target_os = "macos",
         target_os = "linux",
         target_os = "windows",
-        target_os = "freebsd"
+        target_os = "freebsd",
+        target_os = "openbsd"
     ))
 ))]
 compile_error!(
@@ -81,10 +83,29 @@ mod tests {
         assert_matches!(m.threads, Some(_));
     }
 
+    #[cfg(target_os = "openbsd")]
+    #[test]
+    fn test_collect_internal_ok_openbsd() {
+        // TODO: if more metrics is implemented for OpenBSD, merge this test into
+        // test_collect_internal_ok
+        fibonacci(40);
+        let m = collect();
+        dbg!(&m);
+        assert_matches!(m.cpu_seconds_total, Some(_));
+        assert_matches!(m.open_fds, None);
+        assert_matches!(m.max_fds, Some(_));
+        assert_matches!(m.virtual_memory_bytes, None);
+        assert_matches!(m.virtual_memory_max_bytes, None);
+        assert_matches!(m.resident_memory_bytes, Some(_));
+        assert_matches!(m.start_time_seconds, Some(_));
+        assert_matches!(m.threads, None);
+    }
+
     #[cfg(not(target_os = "macos"))]
     #[cfg(not(target_os = "linux"))]
     #[cfg(not(target_os = "windows"))]
     #[cfg(not(target_os = "freebsd"))]
+    #[cfg(not(target_os = "openbsd"))]
     #[cfg(feature = "dummy")]
     #[test]
     fn test_collect_internal_ok_dummy() {

--- a/src/collector/openbsd.rs
+++ b/src/collector/openbsd.rs
@@ -1,0 +1,107 @@
+use std::convert::TryInto as _;
+
+use super::Metrics;
+
+fn getrusage(who: libc::c_int) -> Option<libc::rusage> {
+    let mut usage = std::mem::MaybeUninit::zeroed();
+    // SAFETY: libc call; usage is valid pointer to rusage struct
+    if unsafe { libc::getrusage(who, usage.as_mut_ptr()) } == 0 {
+        // SAFETY: libc call was success, struct must be initialized
+        Some(unsafe { usage.assume_init() })
+    } else {
+        None
+    }
+}
+
+fn getrlimit(resource: libc::c_int) -> Option<libc::rlimit> {
+    let mut limit = std::mem::MaybeUninit::zeroed();
+    // SAFETY: libc call; limit is valid pointer to rlimit struct
+    if unsafe { libc::getrlimit(resource, limit.as_mut_ptr()) } == 0 {
+        // SAFETY: libc call was success, struct must be initialized
+        Some(unsafe { limit.assume_init() })
+    } else {
+        None
+    }
+}
+
+fn translate_rlim(rlim: libc::rlim_t) -> u64 {
+    if rlim == libc::RLIM_INFINITY {
+        0
+    } else {
+        rlim as u64
+    }
+}
+
+fn kinfo_getproc(pid: libc::pid_t) -> Option<libc::kinfo_proc> {
+    let mut kinfo_proc = std::mem::MaybeUninit::zeroed();
+    let kinfo_proc_size = std::mem::size_of_val(&kinfo_proc) as libc::size_t;
+    let mut data_size = kinfo_proc_size;
+
+    // code from deno doing similar stuff: https://github.com/denoland/deno/blob/20ae8db50d7d48ad020b83ebe78dc0e9e9eab3b2/runtime/ops/os/mod.rs#L415
+    let mib = [
+        libc::CTL_KERN,
+        libc::KERN_PROC,
+        libc::KERN_PROC_PID,
+        pid,
+        // this is required because MIB is array of ints, and is safe
+        // as long size of kinfo_proc structure doesn't exceed 2GB
+        kinfo_proc_size.try_into().unwrap(),
+        1,
+    ];
+
+    // SAFETY: libc call; mib is statically initialized, kinfo_proc is valid pointer
+    // to kinfo_proc and data_size holds its size
+    if unsafe {
+        libc::sysctl(
+            mib.as_ptr(),
+            mib.len() as _,
+            kinfo_proc.as_mut_ptr() as *mut libc::c_void,
+            &mut data_size,
+            std::ptr::null_mut(),
+            0,
+        )
+    } == 0
+        && data_size == kinfo_proc_size
+    {
+        // SAFETY: libc call was success and check for struct size passed, struct must be initialized
+        Some(unsafe { kinfo_proc.assume_init() })
+    } else {
+        None
+    }
+}
+
+pub fn collect() -> Metrics {
+    let mut metrics = Metrics::default();
+
+    // TODO: this is based on freebsd.rs, but lacks
+    // - virtual_memory_bytes (kinfo_proc::p_vm_map_size contains zero)
+    // - virtual_memory_max_bytes (openbsd lacks RLIMIT_AS)
+    // - threads (no corresponding field in kinfo_proc(
+    // - open_fds (no idea where to get it from)
+
+    if let Some(usage) = getrusage(libc::RUSAGE_SELF) {
+        metrics.cpu_seconds_total = Some(
+            (usage.ru_utime.tv_sec + usage.ru_stime.tv_sec) as f64
+                + (usage.ru_utime.tv_usec + usage.ru_stime.tv_usec) as f64 / 1000000.0,
+        );
+    }
+
+    if let Some(limit_as) = getrlimit(libc::RLIMIT_NOFILE) {
+        metrics.max_fds = Some(translate_rlim(limit_as.rlim_cur));
+    }
+
+    // SAFETY: libc call
+    let pid = unsafe { libc::getpid() };
+
+    if let Some(kinfo_proc) = kinfo_getproc(pid) {
+        // reference:
+        // https://github.com/openbsd/src/blob/782feb691bc15d1abd5f5c66fe3c0d336903a461/sys/sys/sysctl.h#L370
+
+        // SAFETY: libc call
+        let pagesize = unsafe { libc::sysconf(libc::_SC_PAGESIZE) } as u64;
+        metrics.resident_memory_bytes = Some(kinfo_proc.p_vm_rssize as u64 * pagesize);
+        metrics.start_time_seconds = Some(kinfo_proc.p_ustart_sec);
+    }
+
+    metrics
+}


### PR DESCRIPTION
I was curious about supporting other platforms with the help of `cross-platform-actions`, and it turned out not too hard to add OpenBSD. It still lacks part of the metrics, hopefully OpenBSD uses will improve it (I myself don't have OpenBSD installed).

This PR also makes cross-platform testing more flexible and allows add support for more platforms in the future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced support for OpenBSD, enhancing cross-platform compatibility.
	- Added new metrics collection functionality specific to OpenBSD.
	- Updated testing capabilities to include OpenBSD in the cross-platform test suite.

- **Bug Fixes**
	- Adjusted compilation conditions to ensure compatibility with OpenBSD.

- **Documentation**
	- Updated README to reflect OpenBSD as a supported platform and its corresponding metrics.
	- Revised dependency management to include OpenBSD requirements in project configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->