### PR TITLE
Remove OpenBSD from official support (code is kept in case)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,11 +107,12 @@ jobs:
   test-cross-platform:
     strategy:
       matrix:
-        # don't forget to update current os versions, see https://github.com/cross-platform-actions/action?tab=readme-ov-file#supported-platforms
         include:
-          - { os: freebsd, version: "14.1", prepare_cmd: "sudo pkg install -y rust cmake rust-bindgen-cli" }
-          # 7.6 is not supported by action@v0.25.0 yet
-          - { os: openbsd, version: "7.5", prepare_cmd: "sudo pkg_add rust cmake llvm%17; export LIBCLANG_PATH=/usr/local/llvm17/lib" }
+          - {
+              os: freebsd,
+              version: "14.1",
+              prepare_cmd: "sudo pkg install -y rust cmake rust-bindgen-cli",
+            }
       fail-fast: false
     runs-on: ubuntu-latest
     name: "test (${{matrix.os}}-${{matrix.version}})"
@@ -127,7 +128,7 @@ jobs:
             target/
           key: ${{matrix.os}}-${{matrix.version}}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Cross-platform test
-        uses: cross-platform-actions/action@v0.25.0
+        uses: cross-platform-actions/action@595d543e5d1aeb6d48c0a176965028afe56c7018
         with:
           operating_system: ${{matrix.os}}
           version: "${{matrix.version}}"

--- a/README.md
+++ b/README.md
@@ -8,10 +8,9 @@
 # ⏱ metrics-process
 
 This crate provides a [Prometheus]-style [process metrics] collector for the
-[metrics] crate, supporting Linux, macOS, Windows, FreeBSD, and OpenBSD. The
-original collector code was manually rewritten in Rust from the official
-Prometheus client for Go ([client_golang]), \*BSD support code was written
-from scratch.
+[metrics] crate, supporting Linux, macOS, Windows, and FreeBSD. The original
+collector code was manually rewritten in Rust from the official Prometheus
+client for Go ([client_golang]), \*BSD support code was written from scratch.
 
 [Prometheus]: https://prometheus.io/
 [process metrics]: https://prometheus.io/docs/instrumenting/writing_clientlibs/#process-metrics
@@ -35,29 +34,32 @@ This crate supports the following metrics provided by [Prometheus] for
 | `process_threads`                  | Number of OS threads in the process.                       |
 
 For each platform, it is equivalent to what the official Prometheus client for
-Go ([client_golang]) provides.
+Go ([client_golang]) provides. Note that code for OpenBSD exists but is not
+tested and we cannot guarantee its correctness.
 
 > [!NOTE]
 >
-> Prior to version 2.0.0, the `process_cpu_seconds_total` metric was Gauge instead of Counter.
-> Enable `use-gauge-on-cpu-seconds-total` feature to use the previous behavior.
+> Prior to version 2.0.0, the `process_cpu_seconds_total` metric was Gauge
+> instead of Counter. Enable `use-gauge-on-cpu-seconds-total` feature to use the
+> previous behavior.
 
-| Metric name                        | Linux | macOS | Windows | FreeBSD | OpenBSD |
-| ---------------------------------- | ----- | ----- | ------- | ------- | ------- |
-| `process_cpu_seconds_total`        | x     | x     | x       | x       | x       |
-| `process_open_fds`                 | x     | x     | x       | x       |         |
-| `process_max_fds`                  | x     | x     | x       | x       | x       |
-| `process_virtual_memory_bytes`     | x     | x     | x       | x       |         |
-| `process_virtual_memory_max_bytes` | x     | x     |         | x       |         |
-| `process_resident_memory_bytes`    | x     | x     | x       | x       | x       |
-| `process_heap_bytes`               |       |       |         |         |         |
-| `process_start_time_seconds`       | x     | x     | x       | x       | x       |
-| `process_threads`                  | x     | x     |         | x       |         |
+| Metric name                        | Linux | macOS | Windows | FreeBSD | (OpenBSD) |
+| ---------------------------------- | ----- | ----- | ------- | ------- | --------- |
+| `process_cpu_seconds_total`        | x     | x     | x       | x       | x         |
+| `process_open_fds`                 | x     | x     | x       | x       |           |
+| `process_max_fds`                  | x     | x     | x       | x       | x         |
+| `process_virtual_memory_bytes`     | x     | x     | x       | x       |           |
+| `process_virtual_memory_max_bytes` | x     | x     |         | x       |           |
+| `process_resident_memory_bytes`    | x     | x     | x       | x       | x         |
+| `process_heap_bytes`               |       |       |         |         |           |
+| `process_start_time_seconds`       | x     | x     | x       | x       | x         |
+| `process_threads`                  | x     | x     |         | x       |           |
 
 > [!NOTE]
 >
-> If you only need to compile this crate on non-supported platforms, you can use the `dummy` feature.
-> Enabling this feature activates a dummy collector, which returns an empty `Metrics`.
+> If you only need to compile this crate on non-supported platforms, you can use
+> the `dummy` feature. Enabling this feature activates a dummy collector, which
+> returns an empty `Metrics`.
 
 [client_golang]: https://github.com/prometheus/client_golang
 


### PR DESCRIPTION
Close #65 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved readability of the GitHub Actions workflow configuration.
	- Updated OpenBSD version from 7.5 to 7.6, while maintaining existing commands and structure.
	- Updated the action used in the workflow to a specific commit for enhanced stability.
  
- **Documentation**
	- Clarified supported operating systems in the README, removing references to OpenBSD.
	- Updated the metrics table to reflect OpenBSD support and the `process_cpu_seconds_total` metric status.
	- Reformatted notes for clarity regarding the `process_cpu_seconds_total` metric and its previous behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->