### PR TITLE
Clarify that `process_heap_bytes` is not supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This crate supports the following metrics provided by [Prometheus] for
 | `process_virtual_memory_bytes`     | Virtual memory size in bytes.                              |
 | `process_virtual_memory_max_bytes` | Maximum amount of virtual memory available in bytes.       |
 | `process_resident_memory_bytes`    | Resident memory size in bytes.                             |
-| `process_heap_bytes`               | Process heap size in bytes.                                |
+| ~~`process_heap_bytes`~~               | Process heap size in bytes. **Not supported**                                |
 | `process_start_time_seconds`       | Start time of the process since the Unix epoch in seconds. |
 | `process_threads`                  | Number of OS threads in the process.                       |
 
@@ -51,7 +51,7 @@ tested and we cannot guarantee its correctness.
 | `process_virtual_memory_bytes`     | x     | x     | x       | x       |           |
 | `process_virtual_memory_max_bytes` | x     | x     |         | x       |           |
 | `process_resident_memory_bytes`    | x     | x     | x       | x       | x         |
-| `process_heap_bytes`               |       |       |         |         |           |
+| ~~`process_heap_bytes`~~               |       |       |         |         |           |
 | `process_start_time_seconds`       | x     | x     | x       | x       | x         |
 | `process_threads`                  | x     | x     |         | x       |           |
 


### PR DESCRIPTION
Related https://github.com/lambdalisue/rs-metrics-process/pull/71

<img width="1045" height="1059" alt="CleanShot 2025-10-05 at 15 06 11" src="https://github.com/user-attachments/assets/baf3c8ad-218b-49b0-b19c-92c50febe8ec" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated metrics documentation to mark process_heap_bytes as “Not supported” across the main Supported Metrics and platform-specific tables.
  * Improved clarity by replacing prior references with explicit “Not supported” labeling and consistent formatting.
  * No behavioral or functional changes to the product.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->